### PR TITLE
chore!: switch config to yaml for easier overriding

### DIFF
--- a/chart/templates/renovate-config-secret.yaml
+++ b/chart/templates/renovate-config-secret.yaml
@@ -9,4 +9,4 @@ metadata:
 type: Opaque
 stringData:
   config.json: |-
-    {{- .Values.renovate.config | nindent 4 }}
+    {{- .Values.renovate.config | toJson | nindent 4 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -41,9 +41,8 @@ renovate:
   # that aren't directly exposed by the uds-renovate-config chart. (see: https://docs.renovatebot.com/self-hosted-configuration/)
   extraEnv: {}
 
-  config: |
-    {
-        "enabled": true
-    }
+  config:
+    enabled: true
+
 
 additionalNetworkAllow: []

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ By default the schedule is every 15 minutes (`"*/15 * * * *"`).
 - `renovate.autodiscover` - Autodiscover repositories. Defaults to `true` which enables Renovate to run on all repositories that the bot account can access. See https://docs.renovatebot.com/self-hosted-configuration/#autodiscover
 - `renovate.onboarding` - Require a configuration PR to onboard new repositories to Renovate. Defaults to `true`. See https://docs.renovatebot.com/self-hosted-configuration/#onboarding
 - `renovate.extraEnv` - A map of key value pairs to pass extra environment variables to Renovate for custom configuration options. Any value listed in the [Renovate Self-Hosted configuration options](https://docs.renovatebot.com/self-hosted-configuration/) can be specified here using the `env` variable name from the docs. 
-- `renovate.config` - Renovate config.json file. The contents of this file will be combined with any settings or environment variables specified above. If `renovate.printconfig` is `true` the combined effective config will appear in the pod logs for each execution of Renovate.
+- `renovate.config` - Renovate `config.json` file represented in YAML (YAML keys are the same as those in the `config.json` and are converted toJson iby the template). The contents of this file will be combined with any settings or environment variables specified above. If `renovate.printconfig` is `true` the combined effective config will appear in the pod logs for each execution of Renovate.
 
 ## Redis
 


### PR DESCRIPTION
## Description

This moves the renovate config to a yaml object to provide easier overriding.

> [!CAUTION]
> **BREAKING CHANGE** This is a breaking change because the config object must now be provided as YAML keys instead of a full raw json object

## Related Issue

Fixes #3 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-renovate/blob/main/CONTRIBUTING.md#developer-workflow) followed
