### PR TITLE
chore: fix test timeout flake

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,26 @@
       ":semanticCommits",
       ":semanticCommitTypeAll(chore)"
     ],
+    "ignorePaths": [
+      "**/node_modules/**",
+      "**/bower_components/**",
+      "**/vendor/**",
+      "**/examples/**",
+      "**/__tests__/**",
+      "**/test/**",
+      "**/tests/**",
+      "**/__fixtures__/**",
+      "**/repo-sources/**"
+    ],
+    "nuget": {
+      "ignorePaths": [
+        "**/node_modules/**",
+        "**/bower_components/**",
+        "**/vendor/**",
+        "**/examples/**",
+        "**/__fixtures__/**"
+      ]
+    },
     "packageRules": [
       {
         "groupName": "Renovate Support Dependencies",

--- a/tests/journey/onboard-repos.test.ts
+++ b/tests/journey/onboard-repos.test.ts
@@ -68,7 +68,7 @@ test('upload multiple demo-repos', async () => {
     expect(issueFoundWithRenovateMaven).toBe(false);
     expect(issueFoundWithoutRenovateMaven).toBe(false);
 
-}, 120000);
+}, 150000);
 
 async function inviteRenovateBotToProject(headers: HeadersInit, projectId: any, token: string) {
     const userResp = await fetch(`https://gitlab${domainSuffix}/api/v4/users?username=${renovateUserName}`, { headers });


### PR DESCRIPTION
## Description

This test was missing the timeout by a few millis just often enough to be annoying.

Example:
```
  ✕ upload multiple demo-repos (120003 ms)
  ● upload multiple demo-repos
    thrown: "Exceeded timeout of 120000 ms for a test.
```

Also updated ignorePaths to add 'repo-sources' to the ignore path. This directory contains sources that need to be renovated from within the CI tests and not directly here in this github repo. Had to override the whole block because ignorePaths isn't mergable, so copied the defaults from here and added `**/repo-sources/**` https://docs.renovatebot.com/presets-default/#ignoremodulesandtests -- This should stop PRs like this: https://github.com/defenseunicorns/uds-package-renovate/pull/40
